### PR TITLE
Reset errno before calling strto*

### DIFF
--- a/nxjson.c
+++ b/nxjson.c
@@ -281,6 +281,7 @@ static char* parse_value(nx_json* parent, const char* key, char* p, nx_json_unic
         {
           js=create_json(NX_JSON_INTEGER, key, parent);
           char* pe;
+          errno = 0;
           js->int_value=strtoll(p, &pe, 0);
           if (pe==p || errno==ERANGE) {
             NX_JSON_REPORT_ERROR("invalid number", p);
@@ -288,6 +289,7 @@ static char* parse_value(nx_json* parent, const char* key, char* p, nx_json_unic
           }
           if (*pe=='.' || *pe=='e' || *pe=='E') { // double value
             js->type=NX_JSON_DOUBLE;
+            errno = 0;
             js->dbl_value=strtod(p, &pe);
             if (pe==p || errno==ERANGE) {
               NX_JSON_REPORT_ERROR("invalid number", p);


### PR DESCRIPTION
From `man strtoll`:
> Since strtol() can legitimately return 0, LONG_MAX, or LONG_MIN (LLONG_MAX or LLONG_MIN for strtoll()) on  both  success  and failure,  the  calling  program  should  set  errno to 0 before the call, and then determine if an error occurred by checking whether errno has a nonzero value after the call.

Otherwise you could have a correct result of 0 and incorrectly assume an error because errno is set to whatever it was before if it was not 0.